### PR TITLE
Refocus kassensystem lineup and software section

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,72 +176,237 @@
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="max-w-3xl">
           <h2 class="text-3xl font-extrabold text-ink-900">Quorion Kassensysteme</h2>
-          <p class="mt-2 text-slate-600">QTouch für Handel &amp; Gastro, QMP als kompakte Registrierkassen. QMP-Software: Berichtswesen, E-Journal, LAN/WAN, Mehrsprachigkeit (GoBD/RKSV).</p>
+          <p class="mt-2 text-slate-600">Fokus auf die meistgefragten Modelle für Handel, Gastro &amp; Direktverkauf. Jedes System lässt sich mit QMP Kassensoftware, QCloud &amp; praxisnahen Erweiterungen kombinieren.</p>
         </div>
 
-        <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-          <!-- QTouch 11/12 -->
-          <article class="group rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
+        <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-5">
+          <!-- QTab 9 -->
+          <article class="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
             <figure>
-              <img src="assets/img/quorion/qtouch-11.jpg" alt="Quorion QTouch 11/12 Touch-Kassensystem" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
-              <figcaption class="sr-only">Quorion QTouch 11/12</figcaption>
+              <img src="assets/img/quorion/qtab-9.jpg" alt="Quorion QTab 9 – mobiles Kassensystem" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
+              <figcaption class="sr-only">Quorion QTab 9</figcaption>
             </figure>
-            <div class="p-5">
-              <h3 class="text-lg font-semibold">QTouch 11 / 12</h3>
-              <ul class="mt-2 text-sm text-slate-600">
-                <li class="prose-li">Touch-Kasse für Retail &amp; Gastro</li>
-                <li class="prose-li">Schnelle Bedienung, klare UI</li>
-                <li class="prose-li">Netzwerk &amp; Peripherie</li>
+            <div class="flex flex-1 flex-col p-5">
+              <h3 class="text-lg font-semibold">QTab 9</h3>
+              <ul class="mt-2 flex-1 text-sm text-slate-600">
+                <li class="prose-li">Kompaktes 9″ Tablet-System</li>
+                <li class="prose-li">Akku für mobilen Einsatz</li>
+                <li class="prose-li">WLAN &amp; Cloud synchron</li>
               </ul>
+              <a class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800" href="#qtab9-details">Mehr erfahren</a>
             </div>
           </article>
 
-          <!-- QTouch 15 -->
-          <article class="group rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
+          <!-- QTouch 9 -->
+          <article class="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
             <figure>
-              <img src="assets/img/quorion/qtouch-15.jpg" alt="Quorion QTouch 15 – 15 Zoll Gastrokasse" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
-              <figcaption class="sr-only">Quorion QTouch 15</figcaption>
+              <img src="assets/img/quorion/qtouch-9.jpg" alt="Quorion QTouch 9 Touchkasse" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
+              <figcaption class="sr-only">Quorion QTouch 9</figcaption>
             </figure>
-            <div class="p-5">
-              <h3 class="text-lg font-semibold">QTouch 15 (Gastro)</h3>
-              <ul class="mt-2 text-sm text-slate-600">
-                <li class="prose-li">15″ lüfterlos, robust</li>
-                <li class="prose-li">Küchen-/Bondrucker-Ansteuerung</li>
-                <li class="prose-li">Tisch- &amp; Raumverwaltung</li>
+            <div class="flex flex-1 flex-col p-5">
+              <h3 class="text-lg font-semibold">QTouch 9</h3>
+              <ul class="mt-2 flex-1 text-sm text-slate-600">
+                <li class="prose-li">Lüfterlos &amp; wartungsarm</li>
+                <li class="prose-li">12" Multitouch Display</li>
+                <li class="prose-li">Gastro- &amp; Retail-Layouts</li>
               </ul>
+              <a class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800" href="#qtouch9-details">Mehr erfahren</a>
             </div>
           </article>
 
-          <!-- QMP 2000 -->
-          <article class="group rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
+          <!-- QTouch 11 -->
+          <article class="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
             <figure>
-              <img src="assets/img/quorion/qmp-2000.jpg" alt="Quorion QMP 2000 Registrierkasse" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
-              <figcaption class="sr-only">Quorion QMP 2000</figcaption>
+              <img src="assets/img/quorion/qtouch-11.jpg" alt="Quorion QTouch 11 Touch-Kassensystem" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
+              <figcaption class="sr-only">Quorion QTouch 11</figcaption>
             </figure>
-            <div class="p-5">
-              <h3 class="text-lg font-semibold">QMP 2000</h3>
-              <ul class="mt-2 text-sm text-slate-600">
-                <li class="prose-li">Robuste Registrierkasse</li>
-                <li class="prose-li">E-Journal &amp; Berichte</li>
-                <li class="prose-li">Ideal für Kiosk/Bäckerei</li>
+            <div class="flex flex-1 flex-col p-5">
+              <h3 class="text-lg font-semibold">QTouch 11</h3>
+              <ul class="mt-2 flex-1 text-sm text-slate-600">
+                <li class="prose-li">Erweiterbar mit Kundendisplay</li>
+                <li class="prose-li">Hohe Anschlussvielfalt</li>
+                <li class="prose-li">Ideal für Filialnetze</li>
               </ul>
+              <a class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800" href="#qtouch11-details">Mehr erfahren</a>
             </div>
           </article>
 
-          <!-- QOrder -->
-          <article class="group rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
+          <!-- QTouch 16 -->
+          <article class="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
             <figure>
-              <img src="assets/img/quorion/qorder.jpg" alt="Quorion QOrder Handheld – mobile Bestellung" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
-              <figcaption class="sr-only">Quorion QOrder</figcaption>
+              <img src="assets/img/quorion/qtouch-16.jpg" alt="Quorion QTouch 16 – 16 Zoll Touchkasse" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
+              <figcaption class="sr-only">Quorion QTouch 16</figcaption>
             </figure>
-            <div class="p-5">
-              <h3 class="text-lg font-semibold">QOrder (Handheld)</h3>
-              <ul class="mt-2 text-sm text-slate-600">
-                <li class="prose-li">Mobile Bestellungen am Tisch</li>
-                <li class="prose-li">Direkte Kassen-Anbindung</li>
-                <li class="prose-li">Schneller Service-Workflow</li>
+            <div class="flex flex-1 flex-col p-5">
+              <h3 class="text-lg font-semibold">QTouch 16</h3>
+              <ul class="mt-2 flex-1 text-sm text-slate-600">
+                <li class="prose-li">16" Full HD Touch</li>
+                <li class="prose-li">Leistungsstark für Stoßzeiten</li>
+                <li class="prose-li">Integration von Küchenmonitoren</li>
               </ul>
+              <a class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800" href="#qtouch16-details">Mehr erfahren</a>
             </div>
+          </article>
+
+          <!-- INViCTUS -->
+          <article class="group flex h-full flex-col rounded-2xl border border-slate-200 bg-white shadow-soft transition hover:shadow-glow">
+            <figure>
+              <img src="assets/img/quorion/invictus.jpg" alt="Quorion INViCTUS Kassensystem" class="h-40 w-full rounded-t-2xl object-cover" loading="lazy" />
+              <figcaption class="sr-only">Quorion INViCTUS</figcaption>
+            </figure>
+            <div class="flex flex-1 flex-col p-5">
+              <h3 class="text-lg font-semibold">INViCTUS</h3>
+              <ul class="mt-2 flex-1 text-sm text-slate-600">
+                <li class="prose-li">High-End Performance</li>
+                <li class="prose-li">Aluminium-Gehäuse &amp; IP54</li>
+                <li class="prose-li">Mehrplatz- &amp; Filialbetrieb</li>
+              </ul>
+              <a class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800" href="#invictus-details">Mehr erfahren</a>
+            </div>
+          </article>
+        </div>
+
+        <div class="mt-16 space-y-12">
+          <section id="qtab9-details" class="rounded-3xl bg-white/70 p-8 shadow-soft ring-1 ring-brand-100">
+            <div class="grid gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+              <div>
+                <h3 class="text-2xl font-bold text-ink-900">QTab 9 – flexibel für Foodtrucks &amp; Pop-up Stores</h3>
+                <p class="mt-3 text-slate-600">Das leichte 9″ Kassentablet lässt sich über LTE-Hotspots oder WLAN betreiben. Synchronisation mit QCloud sorgt für Live-Daten und digitale Belege – ideal für wechselnde Standorte.</p>
+                <ul class="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                  <li class="prose-li">Akku bis 8 h Laufzeit</li>
+                  <li class="prose-li">Integrierter Bondrucker optional</li>
+                  <li class="prose-li">QR- und Kartenzahlung mit Worldline Move/5000</li>
+                  <li class="prose-li">Cloud-Artikelpflege via QMP Kassensoftware</li>
+                </ul>
+              </div>
+              <div class="rounded-2xl bg-brand-50/60 p-6 text-sm text-brand-900">
+                <h4 class="text-base font-semibold">Praxislösung</h4>
+                <p class="mt-2">Foodtrucks koppeln QTab 9 mit der Tischbestellungs-App für Vorbestellungen und nutzen QCloud Login zur Tagesauswertung im Homeoffice.</p>
+              </div>
+            </div>
+          </section>
+
+          <section id="qtouch9-details" class="rounded-3xl bg-white/70 p-8 shadow-soft ring-1 ring-brand-100">
+            <div class="grid gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+              <div>
+                <h3 class="text-2xl font-bold text-ink-900">QTouch 9 – kompakte Gastrokasse</h3>
+                <p class="mt-3 text-slate-600">Die QTouch 9 vereint Touchbedienung mit physischen Tasten für Schnellfunktionen. Perfekt für Bars, Cafés und Take-away mit engem Tresen.</p>
+                <ul class="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                  <li class="prose-li">Tischverwaltung &amp; Split-Zahlung</li>
+                  <li class="prose-li">Ansteuerung von Küchen- &amp; Getränkedruckern</li>
+                  <li class="prose-li">LAN, WLAN &amp; Bluetooth-Peripherie</li>
+                  <li class="prose-li">POS Displays Kundenanzeigen-App für Cross-Selling</li>
+                </ul>
+              </div>
+              <div class="rounded-2xl bg-brand-50/60 p-6 text-sm text-brand-900">
+                <h4 class="text-base font-semibold">Praxislösung</h4>
+                <p class="mt-2">In Kombination mit der Tischbestellungs-App werden Bestellungen per QR-Code aufgenommen und direkt in QMP verbucht.</p>
+              </div>
+            </div>
+          </section>
+
+          <section id="qtouch11-details" class="rounded-3xl bg-white/70 p-8 shadow-soft ring-1 ring-brand-100">
+            <div class="grid gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+              <div>
+                <h3 class="text-2xl font-bold text-ink-900">QTouch 11 – Filialfähig &amp; skalierbar</h3>
+                <p class="mt-3 text-slate-600">Mit zahlreichen Schnittstellen (USB, LAN, RS232) lassen sich Scanner, Waagen und Kundendisplays mühelos einbinden. Für Filialnetze stehen Mehrplatz- und Verbundfunktionen bereit.</p>
+                <ul class="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                  <li class="prose-li">QCloud Info für Echtzeitumsätze</li>
+                  <li class="prose-li">Backup &amp; Updates via QCloud Login</li>
+                  <li class="prose-li">Mehrsprachige Bedienoberfläche</li>
+                  <li class="prose-li">Kundenbindung mit Gutscheinen &amp; Coupons</li>
+                </ul>
+              </div>
+              <div class="rounded-2xl bg-brand-50/60 p-6 text-sm text-brand-900">
+                <h4 class="text-base font-semibold">Praxislösung</h4>
+                <p class="mt-2">Bäckereiverbünde nutzen QTouch 11 mit QCloud Info, um jeden Morgen Artikelumsätze filialübergreifend zu analysieren.</p>
+              </div>
+            </div>
+          </section>
+
+          <section id="qtouch16-details" class="rounded-3xl bg-white/70 p-8 shadow-soft ring-1 ring-brand-100">
+            <div class="grid gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+              <div>
+                <h3 class="text-2xl font-bold text-ink-900">QTouch 16 – für hohe Frequenz &amp; große Tische</h3>
+                <p class="mt-3 text-slate-600">Das 16″ Full-HD-Display bietet Platz für umfangreiche Speisekarten, Bonusprogramme und Tischlayouts. Dank SSD und Intel&reg; CPU bleibt das System selbst zu Stoßzeiten schnell.</p>
+                <ul class="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                  <li class="prose-li">Unterstützt QSC Kassenprogramm</li>
+                  <li class="prose-li">Küchenmonitoring &amp; Produktionssteuerung</li>
+                  <li class="prose-li">Sichere Benutzerverwaltung &amp; Rechte</li>
+                  <li class="prose-li">Integration von Worldline Axium EX8000</li>
+                </ul>
+              </div>
+              <div class="rounded-2xl bg-brand-50/60 p-6 text-sm text-brand-900">
+                <h4 class="text-base font-semibold">Praxislösung</h4>
+                <p class="mt-2">Eventlocations kombinieren QTouch 16 mit POS Displays Kundenanzeigen-App, um Sponsorenclips und Upselling-Hinweise am Tresen zu zeigen.</p>
+              </div>
+            </div>
+          </section>
+
+          <section id="invictus-details" class="rounded-3xl bg-white/70 p-8 shadow-soft ring-1 ring-brand-100">
+            <div class="grid gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+              <div>
+                <h3 class="text-2xl font-bold text-ink-900">INViCTUS – Premiumlösung für anspruchsvolle Betriebe</h3>
+                <p class="mt-3 text-slate-600">Die INViCTUS Plattform wurde für 24/7-Betriebe entwickelt. Robustes Metallgehäuse, IP54 Schutz und modulare Leistungsmodule sorgen für maximale Ausfallsicherheit.</p>
+                <ul class="mt-4 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                  <li class="prose-li">Redundante SSD &amp; Remote-Service</li>
+                  <li class="prose-li">Highspeed-Anbindung für Scanner &amp; Automaten</li>
+                  <li class="prose-li">Volle Unterstützung von QMP Kassensoftware</li>
+                  <li class="prose-li">Schnittstellen zu ERP &amp; Lager</li>
+                </ul>
+              </div>
+              <div class="rounded-2xl bg-brand-50/60 p-6 text-sm text-brand-900">
+                <h4 class="text-base font-semibold">Praxislösung</h4>
+                <p class="mt-2">Tankstellen setzen auf INViCTUS mit QCloud Login für Fernwartung und koppeln Worldline Axium DX8000 für Flottenkarten.</p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </section>
+
+    <section id="software" class="bg-brand-50/40 py-20">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <h2 class="text-3xl font-extrabold text-ink-900">Software, Cloud &amp; Apps</h2>
+          <p class="mt-2 text-slate-600">Alle Kassensysteme werden durch modulare Softwarelösungen ergänzt. Sie wählen genau die Komponenten, die Ihren Betriebsabläufen entsprechen.</p>
+        </div>
+
+        <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <article class="rounded-2xl border border-brand-100 bg-white p-6 shadow-soft">
+            <h3 class="text-lg font-semibold text-ink-900">QMP Kassensoftware</h3>
+            <p class="mt-2 text-sm text-slate-600">Modulare Softwarebasis für alle Quorion-Kassen. Unterstützt Artikelpflege, Mitarbeitermanagement, Finanzberichte und Fiskalfunktionen (GoBD/RKSV).</p>
+            <a href="#kontakt" class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800">Demo vereinbaren</a>
+          </article>
+
+          <article class="rounded-2xl border border-brand-100 bg-white p-6 shadow-soft">
+            <h3 class="text-lg font-semibold text-ink-900">QCloud Info</h3>
+            <p class="mt-2 text-sm text-slate-600">Webbasierte Auswertungen in Echtzeit. Umsätze, Journal und Artikelbestände jederzeit abrufbar – auf Wunsch mit individuellen Dashboards.</p>
+            <a href="#kontakt" class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800">Jetzt informieren</a>
+          </article>
+
+          <article class="rounded-2xl border border-brand-100 bg-white p-6 shadow-soft">
+            <h3 class="text-lg font-semibold text-ink-900">QCloud Login</h3>
+            <p class="mt-2 text-sm text-slate-600">Sicherer Fernzugriff für Wartung, Updates und Datenbackup. Ideal für Filialbetriebe und Betreiber mit Homeoffice-Controlling.</p>
+            <a href="#kontakt" class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800">Remote-Zugang anfragen</a>
+          </article>
+
+          <article class="rounded-2xl border border-brand-100 bg-white p-6 shadow-soft">
+            <h3 class="text-lg font-semibold text-ink-900">Tischbestellungs-App</h3>
+            <p class="mt-2 text-sm text-slate-600">Digitale Speisekarte mit QR-Code Bestellung. Gäste bestellen und bezahlen direkt am Tisch, die Küche erhält automatisch die Bons.</p>
+            <a href="#kontakt" class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800">Pilotprojekt starten</a>
+          </article>
+
+          <article class="rounded-2xl border border-brand-100 bg-white p-6 shadow-soft">
+            <h3 class="text-lg font-semibold text-ink-900">POS Displays Kundenanzeigen-App</h3>
+            <p class="mt-2 text-sm text-slate-600">Moderne Kundendisplays für Upselling, Wartezeiten-Informationen und digitale Belege. Inhalte können per QCloud geplant werden.</p>
+            <a href="#kontakt" class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800">Content planen</a>
+          </article>
+
+          <article class="rounded-2xl border border-brand-100 bg-white p-6 shadow-soft">
+            <h3 class="text-lg font-semibold text-ink-900">QSC Kassenprogramm</h3>
+            <p class="mt-2 text-sm text-slate-600">Branchenspezifische Lösung für Schnellrestaurants &amp; Lieferdienste. Enthält Lieferzonen, Fahrerabrechnung und digitale Quittungen.</p>
+            <a href="#kontakt" class="mt-4 inline-flex items-center text-sm font-semibold text-brand-700 transition hover:text-brand-800">Mehr zur Integration</a>
           </article>
         </div>
       </div>
@@ -343,28 +508,34 @@
             </thead>
             <tbody class="divide-y divide-slate-100">
               <tr>
-                <th scope="row" class="px-4 py-3 font-medium">QTouch 11/12</th>
-                <td class="px-4 py-3">Retail/Gastro</td>
-                <td class="px-4 py-3">Schnelle Bedienung, Peripherie</td>
-                <td class="px-4 py-3">Touch-POS</td>
+                <th scope="row" class="px-4 py-3 font-medium">QTab 9</th>
+                <td class="px-4 py-3">Mobile Pop-ups</td>
+                <td class="px-4 py-3">Akkubetrieb, Cloud-Sync</td>
+                <td class="px-4 py-3">Tablet-POS</td>
               </tr>
               <tr>
-                <th scope="row" class="px-4 py-3 font-medium">QTouch 15</th>
-                <td class="px-4 py-3">Gastro</td>
-                <td class="px-4 py-3">15″, lüfterlos, Küche/Bon</td>
-                <td class="px-4 py-3">Tischverwaltung</td>
+                <th scope="row" class="px-4 py-3 font-medium">QTouch 9</th>
+                <td class="px-4 py-3">Bars &amp; Cafés</td>
+                <td class="px-4 py-3">Kompakt, Tasten + Touch</td>
+                <td class="px-4 py-3">Gastro-Modus</td>
               </tr>
               <tr>
-                <th scope="row" class="px-4 py-3 font-medium">QMP 2000</th>
-                <td class="px-4 py-3">Kiosk/Bäckerei</td>
-                <td class="px-4 py-3">Robust, E-Journal</td>
-                <td class="px-4 py-3">Registrierkasse</td>
+                <th scope="row" class="px-4 py-3 font-medium">QTouch 11</th>
+                <td class="px-4 py-3">Filial-Retail</td>
+                <td class="px-4 py-3">Schnittstellen, Kundendisplay</td>
+                <td class="px-4 py-3">Verbundfähig</td>
               </tr>
               <tr>
-                <th scope="row" class="px-4 py-3 font-medium">QOrder</th>
-                <td class="px-4 py-3">Service am Tisch</td>
-                <td class="px-4 py-3">Mobil, direkt angebunden</td>
-                <td class="px-4 py-3">Handheld</td>
+                <th scope="row" class="px-4 py-3 font-medium">QTouch 16</th>
+                <td class="px-4 py-3">Gastronomie groß</td>
+                <td class="px-4 py-3">16″ Full HD, Küchenmonitor</td>
+                <td class="px-4 py-3">QSC Integration</td>
+              </tr>
+              <tr>
+                <th scope="row" class="px-4 py-3 font-medium">INViCTUS</th>
+                <td class="px-4 py-3">24/7 Betriebe</td>
+                <td class="px-4 py-3">IP54, High-End Hardware</td>
+                <td class="px-4 py-3">Redundanz &amp; Remote</td>
               </tr>
               <tr class="bg-slate-50">
                 <th scope="row" class="px-4 py-3 font-medium">Axium EX8000</th>
@@ -403,27 +574,27 @@
         <div class="mt-8 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft">
             <h3 class="font-semibold">Gastronomie</h3>
-            <p class="mt-1 text-sm text-slate-600">QTouch 15 + Axium EX8000 – Bestellung am Tisch, kontaktlos zahlen.</p>
+            <p class="mt-1 text-sm text-slate-600">QTouch 16 + Axium EX8000 – große Tischlayouts, digitale Küche, kontaktlos zahlen.</p>
           </article>
           <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft">
             <h3 class="font-semibold">Café/Bäckerei</h3>
-            <p class="mt-1 text-sm text-slate-600">QTouch 11/12 + Link/2500 – schnell am Tresen.</p>
+            <p class="mt-1 text-sm text-slate-600">QTouch 9 + Link/2500 – kompaktes Tresen-Setup mit Kundendisplay.</p>
           </article>
           <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft">
             <h3 class="font-semibold">Retail/Supermarkt</h3>
-            <p class="mt-1 text-sm text-slate-600">QTouch 15 + Move/5000 – Band/Scanner &amp; mobiler Drucker.</p>
+            <p class="mt-1 text-sm text-slate-600">QTouch 11 + Move/5000 – Scanner, Waagen &amp; mobile Kassenplätze.</p>
           </article>
           <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft">
             <h3 class="font-semibold">Beauty/Salon</h3>
-            <p class="mt-1 text-sm text-slate-600">QTouch 12 + Axium DX8000 – Service &amp; Bon vor Ort.</p>
+            <p class="mt-1 text-sm text-slate-600">QTab 9 + Tap on Mobile – Beratung direkt am Platz, Abschluss per Smartphone.</p>
           </article>
           <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft">
             <h3 class="font-semibold">Hotel</h3>
-            <p class="mt-1 text-sm text-slate-600">QMP 2000 + EX8000 – schneller Check-in.</p>
+            <p class="mt-1 text-sm text-slate-600">INViCTUS + DX8000 – 24/7 Rezeption mit Fernwartung über QCloud.</p>
           </article>
           <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-soft">
             <h3 class="font-semibold">Taxi/Lieferdienst</h3>
-            <p class="mt-1 text-sm text-slate-600">QOrder + EX8000 – mobil, kontaktlos, überall.</p>
+            <p class="mt-1 text-sm text-slate-600">QTab 9 + Move/5000 – mobile Dispo mit Sofortzahlung beim Kunden.</p>
           </article>
         </div>
       </div>
@@ -504,7 +675,7 @@
   <!-- Product schema -->
   <script type="application/ld+json">
   [
-    {"@context":"https://schema.org","@type":"Product","name":"Quorion QTouch 12","brand":{"@type":"Brand","name":"Quorion"},"image":"https://mkkassen.com/assets/img/quorion/qtouch-11.jpg","category":"POS System","description":"Touch-Kassensystem für Retail &amp; Gastronomie mit QMP-Software.","offers":{"@type":"Offer","availability":"https://schema.org/InStock","priceCurrency":"CHF"}},
+    {"@context":"https://schema.org","@type":"Product","name":"Quorion QTouch 16","brand":{"@type":"Brand","name":"Quorion"},"image":"https://mkkassen.com/assets/img/quorion/qtouch-16.jpg","category":"POS System","description":"16″ Touch-Kassensystem für Gastronomie &amp; Events mit QMP Kassensoftware und QSC Integration.","offers":{"@type":"Offer","availability":"https://schema.org/InStock","priceCurrency":"CHF"}},
     {"@context":"https://schema.org","@type":"Product","name":"Worldline Axium EX8000","brand":{"@type":"Brand","name":"Worldline"},"image":"https://mkkassen.com/assets/img/worldline/ex8000.jpg","category":"Payment Terminal","description":"Mobiles Android-Terminal mit QR-Beleg, 4G/WiFi, PCI PTS 6.x.","offers":{"@type":"Offer","availability":"https://schema.org/InStock","priceCurrency":"CHF"}}
   ]
   </script>


### PR DESCRIPTION
## Summary
- replace the kassensysteme grid with the requested QTab 9, QTouch 9, QTouch 11, QTouch 16 and INViCTUS cards including detail sections with use-case guidance
- add a dedicated "Software, Cloud & Apps" section covering QMP Kassensoftware, QCloud, Tischbestellung, POS Displays and QSC integrations
- align comparison table and branch solution examples with the new kassensystem portfolio and update product schema metadata

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cc94fba6a08333996c7d827fc93546